### PR TITLE
Drop tag cache 2

### DIFF
--- a/modules/ingester/instance_search.go
+++ b/modules/ingester/instance_search.go
@@ -189,7 +189,7 @@ func (i *instance) SearchTags(ctx context.Context) (*tempopb.SearchTagsResponse,
 	err := i.visitSearchEntriesLiveTraces(ctx, func(entry *tempofb.SearchEntry) {
 		for i, ii := 0, entry.TagsLength(); i < ii; i++ {
 			entry.Tags(kv, i)
-			key := string(kv.Value(i))
+			key := string(kv.Key())
 			// check the tag is already set, this is more performant with repetitive values
 			if _, ok := tags[key]; !ok {
 				tags[key] = struct{}{}

--- a/pkg/tempofb/searchdata_test.go
+++ b/pkg/tempofb/searchdata_test.go
@@ -101,7 +101,7 @@ func TestContainsTag(t *testing.T) {
 	m.AddTag("key5", "value")
 	m.AddTag("key6", "value")
 
-	e := SearchEntryFromBytes(m.ToBytes())
+	e := NewSearchEntryFromBytes(m.ToBytes())
 
 	kv := &KeyValues{}
 

--- a/pkg/tempofb/searchdata_util.go
+++ b/pkg/tempofb/searchdata_util.go
@@ -145,7 +145,12 @@ func (s *SearchEntry) Contains(k []byte, v []byte, buffer *KeyValues) bool {
 	return ContainsTag(s, buffer, k, v)
 }
 
-func SearchEntryFromBytes(b []byte) *SearchEntry {
+func (s *SearchEntry) Reset(b []byte) {
+	n := flatbuffers.GetUOffsetT(b)
+	s.Init(b, n)
+}
+
+func NewSearchEntryFromBytes(b []byte) *SearchEntry {
 	return GetRootAsSearchEntry(b, 0)
 }
 

--- a/tempodb/search/backend_search_block.go
+++ b/tempodb/search/backend_search_block.go
@@ -28,7 +28,8 @@ func NewBackendSearchBlock(input *StreamingSearchBlock, rw backend.Writer, block
 	var err error
 	ctx := context.TODO()
 	indexPageSize := 100 * 1024
-	kv := &tempofb.KeyValues{} // buffer
+	kv := &tempofb.KeyValues{}  // buffer
+	s := &tempofb.SearchEntry{} // buffer
 
 	// Pinning specific version instead of latest for safety
 	version, err := encoding.FromVersion("v2")
@@ -69,7 +70,7 @@ func NewBackendSearchBlock(input *StreamingSearchBlock, rw backend.Writer, block
 			continue
 		}
 
-		s := tempofb.SearchEntryFromBytes(data)
+		s.Reset(data)
 
 		header.AddEntry(s)
 

--- a/tempodb/search/data_combiner.go
+++ b/tempodb/search/data_combiner.go
@@ -23,13 +23,14 @@ func (*DataCombiner) Combine(_ string, searchData ...[]byte) ([]byte, bool) {
 
 	// Squash all datas into 1
 	data := tempofb.SearchEntryMutable{}
-	kv := &tempofb.KeyValues{} // buffer
+	kv := &tempofb.KeyValues{}   // buffer
+	sd := &tempofb.SearchEntry{} // buffer
 	for _, sb := range searchData {
 		// we append zero-length entries to the WAL even when search is disabled. skipping to prevent unmarshalling and panik :)
 		if len(sb) == 0 {
 			continue
 		}
-		sd := tempofb.SearchEntryFromBytes(sb)
+		sd.Reset(sb)
 		for i, ii := 0, sd.TagsLength(); i < ii; i++ {
 			sd.Tags(kv, i)
 			for j, jj := 0, kv.ValueLength(); j < jj; j++ {

--- a/tempodb/search/pipeline_test.go
+++ b/tempodb/search/pipeline_test.go
@@ -55,7 +55,7 @@ func TestPipelineMatchesTags(t *testing.T) {
 			data := tempofb.SearchEntryMutable{
 				Tags: tempofb.NewSearchDataMapWithData(tc.searchData),
 			}
-			sd := tempofb.SearchEntryFromBytes(data.ToBytes())
+			sd := tempofb.NewSearchEntryFromBytes(data.ToBytes())
 			matches := p.Matches(sd)
 
 			require.Equal(t, tc.shouldMatch, matches)
@@ -125,7 +125,7 @@ func TestPipelineMatchesTraceDuration(t *testing.T) {
 				StartTimeUnixNano: uint64(tc.spanStart),
 				EndTimeUnixNano:   uint64(tc.spanEnd),
 			}
-			sd := tempofb.SearchEntryFromBytes(data.ToBytes())
+			sd := tempofb.NewSearchEntryFromBytes(data.ToBytes())
 			matches := p.Matches(sd)
 
 			require.Equal(t, tc.shouldMatch, matches)
@@ -185,7 +185,7 @@ func TestPipelineMatchesBlock(t *testing.T) {
 
 func BenchmarkPipelineMatches(b *testing.B) {
 
-	entry := tempofb.SearchEntryFromBytes((&tempofb.SearchEntryMutable{
+	entry := tempofb.NewSearchEntryFromBytes((&tempofb.SearchEntryMutable{
 		StartTimeUnixNano: 0,
 		EndTimeUnixNano:   uint64(500 * time.Millisecond / time.Nanosecond), //500ms in nanoseconds
 		Tags: tempofb.NewSearchDataMapWithData(map[string][]string{

--- a/tempodb/search/rescan_blocks.go
+++ b/tempodb/search/rescan_blocks.go
@@ -88,7 +88,7 @@ func newStreamingSearchBlockFromWALReplay(searchFilepath, filename string) (*Str
 
 	blockHeader := tempofb.NewSearchBlockHeaderMutable()
 	records, warning, err := wal.ReplayWALAndGetRecords(f, v, enc, func(bytes []byte) error {
-		entry := tempofb.SearchEntryFromBytes(bytes)
+		entry := tempofb.NewSearchEntryFromBytes(bytes)
 		blockHeader.AddEntry(entry)
 		return nil
 	})

--- a/tempodb/search/streaming_search_block.go
+++ b/tempodb/search/streaming_search_block.go
@@ -83,7 +83,7 @@ func (s *StreamingSearchBlock) Append(ctx context.Context, id common.ID, searchD
 	}
 
 	s.headerMtx.Lock()
-	s.header.AddEntry(tempofb.SearchEntryFromBytes(combined))
+	s.header.AddEntry(tempofb.NewSearchEntryFromBytes(combined))
 	s.headerMtx.Unlock()
 
 	return s.appender.Append(id, combined)
@@ -111,6 +111,8 @@ func (s *StreamingSearchBlock) TagValues(ctx context.Context, tagName string, ta
 
 // Search the streaming block.
 func (s *StreamingSearchBlock) Search(ctx context.Context, p Pipeline, sr *Results) error {
+	entry := &tempofb.SearchEntry{}
+
 	if s.closed.Load() {
 		// Generally this means block has already been deleted
 		return nil
@@ -149,7 +151,7 @@ func (s *StreamingSearchBlock) Search(ctx context.Context, p Pipeline, sr *Resul
 		sr.AddBytesInspected(uint64(len(obj)))
 		sr.AddTraceInspected(1)
 
-		entry := tempofb.SearchEntryFromBytes(obj)
+		entry.Reset(obj)
 
 		if !p.Matches(entry) {
 			continue


### PR DESCRIPTION
Reuse SearchEntry buffer where possible.  Rename `SearchEntryFromBytes` to `NewSearchEntryFromBytes`